### PR TITLE
stm32: add WWDG (window watchdog) driver

### DIFF
--- a/embassy-stm32/src/wdg/mod.rs
+++ b/embassy-stm32/src/wdg/mod.rs
@@ -99,6 +99,159 @@ foreach_peripheral!(
     };
 );
 
+// ============================================================
+// WWDG (Window Watchdog)
+// ============================================================
+
+/// Returns `ceil(duration_us * pclk1_hz / (prescaler_mul * 4096 * 1_000_000))`.
+///
+/// Uses `u64` arithmetic throughout to prevent overflow.
+#[cfg(any(wwdg, test))]
+fn wwdg_ticks(duration_us: u32, pclk1_hz: u32, prescaler_mul: u32) -> u64 {
+    let num = duration_us as u64 * pclk1_hz as u64;
+    let den = prescaler_mul as u64 * 4096 * 1_000_000;
+    (num + den - 1) / den
+}
+
+#[cfg(wwdg)]
+use stm32_metapac::wwdg::vals::Wdgtb;
+
+/// Window watchdog (WWDG) driver.
+///
+/// Once activated via [`WindowWatchdog::new`], the WWDG cannot be stopped
+/// without a system reset.
+///
+/// The counter counts from `T` down to 0x3F (63), triggering a reset when it
+/// reaches 0x3F. Petting the watchdog while the counter is still above the
+/// window register `W` (the *closed window*) also causes an immediate reset.
+///
+/// ```text
+/// T_initial ──count down──▶ W ──count down──▶ 0x40 ──▶ 0x3F (RESET)
+/// |◄──── closed window ────►|◄──── open window ────►|
+/// ```
+#[cfg(wwdg)]
+pub struct WindowWatchdog<'d, T: WwdgInstance> {
+    wdg: PhantomData<&'d mut T>,
+    /// Counter value written to CR on every [`pet`](WindowWatchdog::pet) call.
+    counter: u8,
+}
+
+#[cfg(wwdg)]
+impl<'d, T: WwdgInstance> WindowWatchdog<'d, T> {
+    /// Creates and immediately starts the window watchdog.
+    ///
+    /// - `timeout_us`: total watchdog period in microseconds (counter-to-reset time).
+    /// - `window_us`: closed-window duration in microseconds. During this initial
+    ///   portion of the period, petting the watchdog causes a reset. Pass `0` to
+    ///   disable the window restriction (allow petting at any time within the period).
+    ///   Must be strictly less than `timeout_us`.
+    pub fn new(_instance: Peri<'d, T>, timeout_us: u32, window_us: u32) -> Self {
+        assert!(window_us < timeout_us, "window_us must be less than timeout_us");
+
+        crate::rcc::enable_and_reset::<T>();
+
+        let pclk1 = T::frequency().0;
+
+        // Select the smallest prescaler such that ticks falls in [1, 64].
+        const PRESCALER_MULS: [u32; 8] = [1, 2, 4, 8, 16, 32, 64, 128];
+        let (prescaler_mul, ticks) = unwrap!(
+            PRESCALER_MULS.iter().find_map(|&mul| {
+                let t = wwdg_ticks(timeout_us, pclk1, mul);
+                if (1..=64).contains(&t) {
+                    Some((mul, t))
+                } else {
+                    None
+                }
+            }),
+            "WWDG: timeout_us is out of range for all prescalers"
+        );
+
+        // T = 63 + ticks; T is in [0x40, 0x7F].
+        let t_val = 63u8 + ticks as u8;
+
+        // W = T − floor(window_us * pclk1 / (prescaler_mul * 4096 * 1_000_000)).
+        // When window_us == 0 the closed window is empty and W == T.
+        let den = prescaler_mul as u64 * 4096 * 1_000_000;
+        let closed_ticks = (window_us as u64 * pclk1 as u64) / den;
+        let w_val = t_val - closed_ticks as u8;
+
+        let wdgtb = match prescaler_mul {
+            1 => Wdgtb::DIV1,
+            2 => Wdgtb::DIV2,
+            4 => Wdgtb::DIV4,
+            8 => Wdgtb::DIV8,
+            16 => Wdgtb::DIV16,
+            32 => Wdgtb::DIV32,
+            64 => Wdgtb::DIV64,
+            128 => Wdgtb::DIV128,
+            _ => unreachable!(),
+        };
+
+        let regs = T::regs();
+
+        // Write CFR before CR: prescaler and window must be set before activation.
+        regs.cfr().write(|cfr| {
+            cfr.set_wdgtb(wdgtb);
+            cfr.set_w(w_val);
+        });
+
+        // Activate watchdog (WDGA = 1 is hardware-irreversible).
+        regs.cr().write(|cr| {
+            cr.set_t(t_val);
+            cr.set_wdga(true);
+        });
+
+        trace!(
+            "WWDG configured: timeout={}us window={}us pclk1={} prescaler=x{} T={} W={}",
+            timeout_us,
+            window_us,
+            pclk1,
+            prescaler_mul,
+            t_val,
+            w_val,
+        );
+
+        WindowWatchdog {
+            wdg: PhantomData,
+            counter: t_val,
+        }
+    }
+
+    /// Pet (reload) the watchdog.
+    ///
+    /// Must be called while the counter has fallen into the open window
+    /// (counter ≤ W). Calling too early (counter > W) causes an immediate reset.
+    pub fn pet(&mut self) {
+        T::regs().cr().write(|cr| {
+            cr.set_t(self.counter);
+            cr.set_wdga(true);
+        });
+    }
+}
+
+#[cfg(wwdg)]
+trait WwdgSealedInstance {
+    fn regs() -> crate::pac::wwdg::Wwdg;
+}
+
+/// WWDG instance trait.
+#[cfg(wwdg)]
+#[allow(private_bounds)]
+pub trait WwdgInstance: WwdgSealedInstance + PeripheralType + crate::rcc::RccPeripheral {}
+
+#[cfg(wwdg)]
+foreach_peripheral!(
+    (wwdg, $inst:ident) => {
+        impl WwdgSealedInstance for crate::peripherals::$inst {
+            fn regs() -> crate::pac::wwdg::Wwdg {
+                crate::pac::$inst
+            }
+        }
+
+        impl WwdgInstance for crate::peripherals::$inst {}
+    };
+);
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -120,5 +273,44 @@ mod tests {
         assert_eq!(0xFFF, reload_value(256, 32_768_000));
 
         assert_eq!(3999, reload_value(64, 8_000_000));
+    }
+}
+
+#[cfg(test)]
+mod wwdg_tests {
+    use super::wwdg_ticks;
+
+    // Typical PCLK1 frequency for STM32WBA65 at 64 MHz.
+    const PCLK1: u32 = 64_000_000;
+
+    #[test]
+    fn ticks_rounded_up() {
+        // 1000 µs * 64 MHz / (1 * 4096 * 1e6) = 15.625 → ceil = 16
+        assert_eq!(16, wwdg_ticks(1_000, PCLK1, 1));
+    }
+
+    #[test]
+    fn ticks_exact() {
+        // 1024 µs * 64 MHz / (1 * 4096 * 1e6) = 16.0 exactly
+        assert_eq!(16, wwdg_ticks(1_024, PCLK1, 1));
+    }
+
+    #[test]
+    fn ticks_just_above_exact() {
+        // 1025 µs → ceil(16.015625) = 17
+        assert_eq!(17, wwdg_ticks(1_025, PCLK1, 1));
+    }
+
+    #[test]
+    fn ticks_large_prescaler() {
+        // 100 ms, prescaler 128:
+        // 100_000 * 64_000_000 / (128 * 4096 * 1e6) ≈ 12.207 → ceil = 13
+        assert_eq!(13, wwdg_ticks(100_000, PCLK1, 128));
+    }
+
+    #[test]
+    fn ticks_minimum_duration() {
+        // 1 µs: ceil(64_000_000 / 4_096_000_000) = 1
+        assert_eq!(1, wwdg_ticks(1, PCLK1, 1));
     }
 }

--- a/examples/stm32wba6/src/bin/wwdg.rs
+++ b/examples/stm32wba6/src/bin/wwdg.rs
@@ -1,0 +1,53 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::Config;
+use embassy_stm32::rcc::{
+    AHB5Prescaler, AHBPrescaler, APBPrescaler, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale,
+};
+use embassy_stm32::wdg::WindowWatchdog;
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = Config::default();
+    // Fine-tune PLL1 dividers/multipliers
+    config.rcc.pll1 = Some(embassy_stm32::rcc::Pll {
+        source: PllSource::HSI,
+        prediv: PllPreDiv::DIV1,  // PLLM = 1 → HSI / 1 = 16 MHz
+        mul: PllMul::MUL30,       // PLLN = 30 → 16 MHz * 30 = 480 MHz VCO
+        divr: Some(PllDiv::DIV5), // PLLR = 5 → 96 MHz (Sysclk)
+        // divq: Some(PllDiv::DIV10), // PLLQ = 10 → 48 MHz (NOT USED)
+        divq: None,
+        divp: Some(PllDiv::DIV30), // PLLP = 30 → 16 MHz (USBOTG)
+        frac: Some(0),             // Fractional part (enabled)
+    });
+
+    config.rcc.ahb_pre = AHBPrescaler::DIV1;
+    config.rcc.apb1_pre = APBPrescaler::DIV1;
+    config.rcc.apb2_pre = APBPrescaler::DIV1;
+    config.rcc.apb7_pre = APBPrescaler::DIV1;
+    config.rcc.ahb5_pre = AHB5Prescaler::DIV4;
+
+    // voltage scale for max performance
+    config.rcc.voltage_scale = VoltageScale::RANGE1;
+    // route PLL1_R into Sysclk
+    config.rcc.sys = Sysclk::PLL1_R;
+
+    let p = embassy_stm32::init(config);
+    info!("WWDG example");
+
+    // 200 ms total period; the first 100 ms is the closed window.
+    // Petting the watchdog within 100 ms of the last reload causes an immediate reset.
+    let mut wdg = WindowWatchdog::new(p.WWDG, 200_000, 100_000);
+
+    loop {
+        // Wait until we are inside the open window (100–200 ms after last reload).
+        Timer::after_millis(150).await;
+        info!("pet");
+        wdg.pet();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `WindowWatchdog` driver for STM32 chips with a `wwdg_v2`
  peripheral (3-bit prescaler, DIV1–DIV128).
- Automatically selects the smallest prescaler that fits the requested
  timeout within the 64-tick counter range.
- Supports a configurable closed window (`window_us`); pass `0` for no
  window restriction.
- All driver code is `#[cfg(wwdg)]`-gated; activating the watchdog
  (WDGA=1) is irreversible without a system reset.
- Includes host-runnable unit tests for the tick-calculation math.
- Adds a stm32wba6 example demonstrating a 200 ms period with a 100 ms
  closed window.